### PR TITLE
Audio interruption support

### DIFF
--- a/lib/src/waveform_recorder_controller.dart
+++ b/lib/src/waveform_recorder_controller.dart
@@ -35,6 +35,7 @@ class WaveformRecorderController extends ChangeNotifier {
           echoCancel: config?.echoCancel ?? false,
           noiseSuppress: config?.noiseSuppress ?? false,
           androidConfig: config?.androidConfig ?? const AndroidRecordConfig(),
+          audioInterruption: config?.audioInterruption ?? AudioInterruptionMode.pause,
           iosConfig: config?.iosConfig ?? const IosRecordConfig(),
         );
 

--- a/lib/waveform_recorder.dart
+++ b/lib/waveform_recorder.dart
@@ -6,6 +6,7 @@ export 'package:record/record.dart'
         InputDevice,
         IosAudioCategoryOption,
         IosRecordConfig,
+        AudioInterruptionMode,
         RecordConfig;
 
 export 'src/waveform_recorder.dart';


### PR DESCRIPTION
This pull request introduces support for handling audio interruptions in the waveform recorder by exposing the `AudioInterruptionMode` configuration option. This allows users to specify how the recorder should behave when an audio interruption occurs (e.g., pause or stop recording).

**Audio interruption support:**

* Added the `audioInterruption` field to the recorder configuration in `WaveformRecorderController`, defaulting to `AudioInterruptionMode.pause`.
* Exported `AudioInterruptionMode` from the package's main export file to make it available to users.